### PR TITLE
chore: modify urls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org
 root = true
 
 [*]

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage
 # nyc test coverage
 .nyc_output
 
-# Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
+# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 
 # Bower dependency directory (https://bower.io/)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Blaine Bublitz <blaine.bublitz@gmail.com>, Eric Schoffstall <yo@contra.io>.
+Copyright (c) 2021-2023 Blaine Bublitz <blaine.bublitz@gmail.com> and Eric Schoffstall <yo@contra.io>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 Blaine Bublitz <blaine.bublitz@gmail.com>, Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2023 Blaine Bublitz <blaine.bublitz@gmail.com>, Eric Schoffstall <yo@contra.io>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="http://gulpjs.com">
+  <a href="https://gulpjs.com">
     <img height="257" width="114" src="https://raw.githubusercontent.com/gulpjs/artwork/master/gulp-2x.png">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/$PROJECT_NAME.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/$PROJECT_NAME/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/$PROJECT_NAME/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/$PROJECT_NAME/dev.yml?branch=master&style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/$PROJECT_NAME
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/$PROJECT_NAME/master.svg?style=flat-square


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by badges/shields's issue #8671.
This PR fixes the URL in README.md.

In addition, this PR also modifies `http:` to `https:` in some URLs.